### PR TITLE
feat: adapt the API to use initial state + certificates as inputs

### DIFF
--- a/pessimistic_proof/Cargo.lock
+++ b/pessimistic_proof/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +869,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,8 +1477,10 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.0",
  "hex",
+ "lazy_static",
  "reth-primitives",
  "rs_merkle",
+ "rstest",
  "serde",
  "serde_json",
  "serde_with",
@@ -1527,10 +1639,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reth-codecs"
@@ -1706,6 +1847,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b241d2e59b74ef9e98d94c78c47623d04c8392abaf82014dfd372a16041128f"
 dependencies = [
  "sha2",
+]
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.59",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1946,6 +2117,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/pessimistic_proof/Cargo.toml
+++ b/pessimistic_proof/Cargo.toml
@@ -18,4 +18,6 @@ sp1-derive = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.2-testne
 
 [dev-dependencies]
 hex = "0.4.3"
+lazy_static = "1.4.0"
 rs_merkle = { version = "1.4", default-features = false }
+rstest = "0.21.0"

--- a/pessimistic_proof/src/certificate.rs
+++ b/pessimistic_proof/src/certificate.rs
@@ -12,8 +12,8 @@ use crate::{
 
 /// Represents the required data from each CDK for the pessimistic proof.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Batch {
-    /// Origin network which emitted this batch
+pub struct Certificate {
+    /// Origin network which emitted this certificate
     pub origin_network: NetworkId,
     /// Initial local exit tree
     pub prev_local_exit_tree: LocalExitTree<Keccak256Hasher>,
@@ -25,8 +25,8 @@ pub struct Batch {
     pub withdrawals: Vec<Withdrawal>,
 }
 
-impl Batch {
-    /// Creates a new [`Batch`].
+impl Certificate {
+    /// Creates a new [`Certificate`].
     pub fn new(
         origin_network: NetworkId,
         prev_local_exit_tree: LocalExitTree<Keccak256Hasher>,

--- a/pessimistic_proof/src/certificate.rs
+++ b/pessimistic_proof/src/certificate.rs
@@ -1,26 +1,14 @@
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    keccak::Digest,
-    local_balance_tree::{BalanceTree, BalanceTreeByNetwork},
-    local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
-    withdrawal::NetworkId,
-    Withdrawal,
-};
+use crate::{keccak::Digest, withdrawal::NetworkId, Withdrawal};
 
-/// Represents the required data from each CDK for the pessimistic proof.
+/// Represents the data submitted by the CDKs to the AggLayer.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Certificate {
     /// Origin network which emitted this certificate
     pub origin_network: NetworkId,
-    /// Initial local exit tree
-    pub prev_local_exit_tree: LocalExitTree<Keccak256Hasher>,
     /// Initial local exit root
     pub prev_local_exit_root: Digest,
-    /// Initial balance tree
-    pub prev_local_balance_tree: BalanceTree,
     /// Set of withdrawals
     pub withdrawals: Vec<Withdrawal>,
 }
@@ -29,43 +17,14 @@ impl Certificate {
     /// Creates a new [`Certificate`].
     pub fn new(
         origin_network: NetworkId,
-        prev_local_exit_tree: LocalExitTree<Keccak256Hasher>,
         prev_local_exit_root: Digest,
-        prev_local_balance_tree: BalanceTree,
         withdrawals: Vec<Withdrawal>,
     ) -> Self {
         Self {
             origin_network,
-            prev_local_exit_tree,
             prev_local_exit_root,
-            prev_local_balance_tree,
             withdrawals,
         }
     }
-
-    /// Compute the new exit root.
-    pub fn compute_new_exit_root(&self) -> Digest {
-        let mut new_local_exit_tree = self.prev_local_exit_tree.clone();
-
-        for withdrawal in &self.withdrawals {
-            new_local_exit_tree.add_leaf(withdrawal.hash());
-        }
-
-        new_local_exit_tree.get_root()
-    }
-
-    /// Compute the new balance tree.
-    pub fn compute_new_balance_tree(&self) -> BalanceTreeByNetwork {
-        let mut aggregate: BalanceTreeByNetwork = {
-            let base: BTreeMap<NetworkId, BalanceTree> =
-                [(self.origin_network, self.prev_local_balance_tree.clone())].into();
-            base.into()
-        };
-
-        for withdrawal in &self.withdrawals {
-            aggregate.insert(self.origin_network, withdrawal.clone());
-        }
-
-        aggregate
-    }
 }
+

--- a/pessimistic_proof/src/global_state.rs
+++ b/pessimistic_proof/src/global_state.rs
@@ -1,0 +1,103 @@
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    certificate::Certificate,
+    local_balance_tree::BalanceTreeByNetwork,
+    local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
+    proof::{BalanceRoot, ExitRoot},
+    FullProofOutput, NetworkId, ProofError,
+};
+
+/// Represents the global state tracked by the AggLayer.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct State {
+    pub global_exit_tree: BTreeMap<NetworkId, LocalExitTree<Keccak256Hasher>>,
+    pub global_balance_tree: BalanceTreeByNetwork,
+}
+
+impl State {
+    pub fn get_checkpoint(&self) -> FullProofOutput {
+        let ger: HashMap<NetworkId, ExitRoot> = self
+            .global_exit_tree
+            .iter()
+            .map(|(network, exit_tree)| (*network, exit_tree.get_root()))
+            .collect();
+
+        let gbr: HashMap<NetworkId, BalanceRoot> = self
+            .global_balance_tree
+            .iter()
+            .map(|(network, balance_tree)| (*network, balance_tree.hash()))
+            .collect();
+
+        (ger, gbr)
+    }
+
+    /// Apply the [`Certificate`] on the current [`State`].
+    /// Returns the new [`ExitRoot`] if successful write.
+    pub fn apply_certificate(&mut self, certificate: Certificate) -> Result<ExitRoot, ProofError> {
+        let origin_network = certificate.origin_network;
+
+        // Apply on Exit Tree
+        let new_local_exit_tree = {
+            let mut local_exit_tree =
+                self.global_exit_tree.get(&origin_network).expect("unknown").clone();
+            let computed_root = local_exit_tree.get_root();
+            if computed_root != certificate.prev_local_exit_root {
+                return Err(ProofError::InvalidLocalExitRoot {
+                    got: computed_root,
+                    expected: certificate.prev_local_exit_root,
+                });
+            }
+
+            for withdrawal in &certificate.withdrawals {
+                local_exit_tree.add_leaf(withdrawal.hash());
+            }
+
+            local_exit_tree
+        };
+
+        // Apply on Balance Tree
+        let new_balance_tree_by_network = {
+            let mut new_balance_tree_by_network = self.global_balance_tree.clone();
+
+            for withdrawal in &certificate.withdrawals {
+                new_balance_tree_by_network.insert(certificate.origin_network, withdrawal.clone());
+            }
+
+            new_balance_tree_by_network
+        };
+
+        // Check whether the sender has some debt
+        if let Some(balance_tree) = new_balance_tree_by_network.get(&certificate.origin_network) {
+            if balance_tree.has_debt() {
+                return Err(ProofError::HasDebt {
+                    network: certificate.origin_network,
+                });
+            }
+        };
+
+        // All good, let's apply on the globals
+        self.global_exit_tree
+            .entry(origin_network)
+            .and_modify(|current_let| *current_let = new_local_exit_tree.clone());
+
+        self.global_balance_tree = new_balance_tree_by_network;
+
+        Ok(new_local_exit_tree.get_root())
+    }
+
+    pub fn apply_certificates_from(
+        &mut self,
+        _origin_network: NetworkId,
+        certificates: Vec<Certificate>,
+    ) -> Result<(), ProofError> {
+        // TODO: Check linkage among them
+        for c in certificates {
+            self.apply_certificate(c)?;
+        }
+
+        Ok(())
+    }
+}

--- a/pessimistic_proof/src/lib.rs
+++ b/pessimistic_proof/src/lib.rs
@@ -9,6 +9,6 @@ pub mod test_utils;
 mod withdrawal;
 pub use withdrawal::{NetworkId, TokenInfo, Withdrawal};
 
-pub mod batch;
+pub mod certificate;
 
 pub mod local_balance_tree;

--- a/pessimistic_proof/src/lib.rs
+++ b/pessimistic_proof/src/lib.rs
@@ -2,7 +2,7 @@ pub mod keccak;
 pub mod local_exit_tree;
 
 mod proof;
-pub use proof::{generate_full_proof, FullProofOutput, ProofError};
+pub use proof::{generate_full_proof_with_state, FullProofOutput, ProofError, State};
 
 pub mod test_utils;
 

--- a/pessimistic_proof/src/lib.rs
+++ b/pessimistic_proof/src/lib.rs
@@ -2,7 +2,7 @@ pub mod keccak;
 pub mod local_exit_tree;
 
 mod proof;
-pub use proof::{generate_full_proof, ProofError};
+pub use proof::{generate_full_proof, FullProofOutput, ProofError};
 
 pub mod test_utils;
 

--- a/pessimistic_proof/src/lib.rs
+++ b/pessimistic_proof/src/lib.rs
@@ -2,13 +2,15 @@ pub mod keccak;
 pub mod local_exit_tree;
 
 mod proof;
-pub use proof::{generate_full_proof_with_state, FullProofOutput, ProofError, State};
+pub use proof::{generate_full_proof_with_state, FullProofOutput, ProofError};
 
 pub mod test_utils;
+
+pub mod certificate;
+pub mod local_balance_tree;
 
 mod withdrawal;
 pub use withdrawal::{NetworkId, TokenInfo, Withdrawal};
 
-pub mod certificate;
-
-pub mod local_balance_tree;
+pub mod global_state;
+pub use global_state::State;

--- a/pessimistic_proof/src/proof.rs
+++ b/pessimistic_proof/src/proof.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     certificate::Certificate,
     keccak::Digest,
-    local_balance_tree::{merge_balance_trees, BalanceTreeByNetwork},
+    local_balance_tree::BalanceTreeByNetwork,
+    local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
     withdrawal::NetworkId,
 };
 
@@ -12,55 +13,135 @@ use crate::{
 pub enum ProofError {
     InvalidLocalExitRoot { got: Digest, expected: Digest },
     NotEnoughBalance { debtors: Vec<NetworkId> },
+    HasDebt { network: NetworkId },
 }
 
 pub type ExitRoot = Digest;
 pub type BalanceRoot = Digest;
 pub type FullProofOutput = (HashMap<NetworkId, ExitRoot>, HashMap<NetworkId, BalanceRoot>);
 
-/// Returns the updated local balance and exit roots for each network.
-pub fn generate_full_proof(certificates: &[Certificate]) -> Result<FullProofOutput, ProofError> {
-    // Check the validity of the provided exit roots
-    for certificate in certificates {
-        let computed_root = certificate.prev_local_exit_tree.get_root();
+///
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct State {
+    pub global_exit_tree: BTreeMap<NetworkId, LocalExitTree<Keccak256Hasher>>,
+    pub global_balance_tree: BalanceTreeByNetwork,
+}
 
-        if computed_root != certificate.prev_local_exit_root {
-            return Err(ProofError::InvalidLocalExitRoot {
-                got: computed_root,
-                expected: certificate.prev_local_exit_root,
-            });
-        }
+impl State {
+    pub fn get_checkpoint(&self) -> FullProofOutput {
+        let ger: HashMap<NetworkId, ExitRoot> = self
+            .global_exit_tree
+            .iter()
+            .map(|(network, exit_tree)| (*network, exit_tree.get_root()))
+            .collect();
+
+        let gbr: HashMap<NetworkId, BalanceRoot> = self
+            .global_balance_tree
+            .iter()
+            .map(|(network, balance_tree)| (*network, balance_tree.hash()))
+            .collect();
+
+        (ger, gbr)
     }
 
-    // Compute the new exit root
-    let exit_roots: HashMap<NetworkId, ExitRoot> = certificates
-        .iter()
-        .map(|certificate| (certificate.origin_network, certificate.compute_new_exit_root()))
-        .collect();
+    /// Apply the [`Certificate`] on the current [`State`].
+    /// Returns the new [`ExitRoot`] if successful write.
+    #[allow(dead_code)]
+    pub fn apply_certificate(&mut self, certificate: Certificate) -> Result<ExitRoot, ProofError> {
+        let origin_network = certificate.origin_network;
 
-    // Compute the new balance tree by network
-    let balance_trees: HashMap<NetworkId, BalanceTreeByNetwork> = certificates
-        .iter()
-        .map(|certificate| (certificate.origin_network, certificate.compute_new_balance_tree()))
-        .collect();
+        // Apply on Exit Tree
+        let new_local_exit_tree = {
+            let mut local_exit_tree =
+                self.global_exit_tree.get(&origin_network).expect("unknown").clone();
+            let computed_root = local_exit_tree.get_root();
+            if computed_root != certificate.prev_local_exit_root {
+                return Err(ProofError::InvalidLocalExitRoot {
+                    got: computed_root,
+                    expected: certificate.prev_local_exit_root,
+                });
+            }
 
-    // Merge the balance tree by network
-    let balance_tree_by_network: BalanceTreeByNetwork = merge_balance_trees(&balance_trees);
+            for withdrawal in &certificate.withdrawals {
+                local_exit_tree.add_leaf(withdrawal.hash());
+            }
 
-    // Detect the debtors if any
-    let debtors = balance_tree_by_network
-        .iter()
-        .filter_map(|(network, balance_tree)| balance_tree.has_debt().then(|| *network))
-        .collect::<Vec<_>>();
+            local_exit_tree
+        };
+
+        // Apply on Balance Tree
+        let new_balance_tree_by_network = {
+            let mut new_balance_tree_by_network = self.global_balance_tree.clone();
+
+            for withdrawal in &certificate.withdrawals {
+                new_balance_tree_by_network.insert(certificate.origin_network, withdrawal.clone());
+            }
+
+            new_balance_tree_by_network
+        };
+
+        // Check whether the sender has some debt
+        if let Some(balance_tree) = new_balance_tree_by_network.get(&certificate.origin_network) {
+            if balance_tree.has_debt() {
+                return Err(ProofError::HasDebt {
+                    network: certificate.origin_network,
+                });
+            }
+        };
+
+        // All good, let's apply on the globals
+        self.global_exit_tree
+            .entry(origin_network)
+            .and_modify(|current_let| *current_let = new_local_exit_tree.clone());
+
+        self.global_balance_tree = new_balance_tree_by_network;
+
+        Ok(new_local_exit_tree.get_root())
+    }
+
+    pub fn apply_certificates_from(
+        &mut self,
+        _origin_network: NetworkId,
+        certificates: Vec<Certificate>,
+    ) -> Result<(), ProofError> {
+        // TODO: Check linkage among them
+        for c in certificates {
+            self.apply_certificate(c)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn generate_full_proof_with_state(
+    initial_state: State,
+    certificates: Vec<Certificate>,
+) -> Result<FullProofOutput, ProofError> {
+    // Apply all certificates per network bucket
+    let mut certificate_by_network: BTreeMap<NetworkId, Vec<Certificate>> = BTreeMap::new();
+    for certificate in certificates {
+        certificate_by_network
+            .entry(certificate.origin_network)
+            .or_default()
+            .push(certificate);
+    }
+
+    let mut debtors = Vec::new();
+
+    // Per network, apply all or nothing
+    let mut state_candidate = initial_state.clone();
+    for (network, certificates) in certificate_by_network {
+        let ret = state_candidate.apply_certificates_from(network, certificates);
+
+        if let Err(ProofError::HasDebt { network }) = ret {
+            debtors.push(network);
+        }
+    }
 
     if !debtors.is_empty() {
         return Err(ProofError::NotEnoughBalance { debtors });
     }
 
-    let balance_roots: HashMap<NetworkId, BalanceRoot> = balance_tree_by_network
-        .iter()
-        .map(|(network, balance_tree)| (*network, balance_tree.hash()))
-        .collect();
-
-    Ok((exit_roots, balance_roots))
+    Ok(state_candidate.get_checkpoint())
 }

--- a/pessimistic_proof/src/proof.rs
+++ b/pessimistic_proof/src/proof.rs
@@ -1,12 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use crate::{
-    certificate::Certificate,
-    keccak::Digest,
-    local_balance_tree::BalanceTreeByNetwork,
-    local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
-    withdrawal::NetworkId,
-};
+use crate::{certificate::Certificate, keccak::Digest, withdrawal::NetworkId, State};
 
 /// Represents all errors that can occur while generating the proof.
 #[derive(Debug)]
@@ -19,100 +13,6 @@ pub enum ProofError {
 pub type ExitRoot = Digest;
 pub type BalanceRoot = Digest;
 pub type FullProofOutput = (HashMap<NetworkId, ExitRoot>, HashMap<NetworkId, BalanceRoot>);
-
-///
-#[allow(dead_code)]
-#[derive(Clone)]
-pub struct State {
-    pub global_exit_tree: BTreeMap<NetworkId, LocalExitTree<Keccak256Hasher>>,
-    pub global_balance_tree: BalanceTreeByNetwork,
-}
-
-impl State {
-    pub fn get_checkpoint(&self) -> FullProofOutput {
-        let ger: HashMap<NetworkId, ExitRoot> = self
-            .global_exit_tree
-            .iter()
-            .map(|(network, exit_tree)| (*network, exit_tree.get_root()))
-            .collect();
-
-        let gbr: HashMap<NetworkId, BalanceRoot> = self
-            .global_balance_tree
-            .iter()
-            .map(|(network, balance_tree)| (*network, balance_tree.hash()))
-            .collect();
-
-        (ger, gbr)
-    }
-
-    /// Apply the [`Certificate`] on the current [`State`].
-    /// Returns the new [`ExitRoot`] if successful write.
-    #[allow(dead_code)]
-    pub fn apply_certificate(&mut self, certificate: Certificate) -> Result<ExitRoot, ProofError> {
-        let origin_network = certificate.origin_network;
-
-        // Apply on Exit Tree
-        let new_local_exit_tree = {
-            let mut local_exit_tree =
-                self.global_exit_tree.get(&origin_network).expect("unknown").clone();
-            let computed_root = local_exit_tree.get_root();
-            if computed_root != certificate.prev_local_exit_root {
-                return Err(ProofError::InvalidLocalExitRoot {
-                    got: computed_root,
-                    expected: certificate.prev_local_exit_root,
-                });
-            }
-
-            for withdrawal in &certificate.withdrawals {
-                local_exit_tree.add_leaf(withdrawal.hash());
-            }
-
-            local_exit_tree
-        };
-
-        // Apply on Balance Tree
-        let new_balance_tree_by_network = {
-            let mut new_balance_tree_by_network = self.global_balance_tree.clone();
-
-            for withdrawal in &certificate.withdrawals {
-                new_balance_tree_by_network.insert(certificate.origin_network, withdrawal.clone());
-            }
-
-            new_balance_tree_by_network
-        };
-
-        // Check whether the sender has some debt
-        if let Some(balance_tree) = new_balance_tree_by_network.get(&certificate.origin_network) {
-            if balance_tree.has_debt() {
-                return Err(ProofError::HasDebt {
-                    network: certificate.origin_network,
-                });
-            }
-        };
-
-        // All good, let's apply on the globals
-        self.global_exit_tree
-            .entry(origin_network)
-            .and_modify(|current_let| *current_let = new_local_exit_tree.clone());
-
-        self.global_balance_tree = new_balance_tree_by_network;
-
-        Ok(new_local_exit_tree.get_root())
-    }
-
-    pub fn apply_certificates_from(
-        &mut self,
-        _origin_network: NetworkId,
-        certificates: Vec<Certificate>,
-    ) -> Result<(), ProofError> {
-        // TODO: Check linkage among them
-        for c in certificates {
-            self.apply_certificate(c)?;
-        }
-
-        Ok(())
-    }
-}
 
 pub fn generate_full_proof_with_state(
     initial_state: State,

--- a/pessimistic_proof/src/proof.rs
+++ b/pessimistic_proof/src/proof.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    batch::Batch,
+    certificate::Certificate,
     keccak::Digest,
     local_balance_tree::{merge_balance_trees, BalanceTreeByNetwork},
     withdrawal::NetworkId,
@@ -19,29 +19,29 @@ pub type BalanceRoot = Digest;
 pub type FullProofOutput = (HashMap<NetworkId, ExitRoot>, HashMap<NetworkId, BalanceRoot>);
 
 /// Returns the updated local balance and exit roots for each network.
-pub fn generate_full_proof(batches: &[Batch]) -> Result<FullProofOutput, ProofError> {
+pub fn generate_full_proof(certificates: &[Certificate]) -> Result<FullProofOutput, ProofError> {
     // Check the validity of the provided exit roots
-    for batch in batches {
-        let computed_root = batch.prev_local_exit_tree.get_root();
+    for certificate in certificates {
+        let computed_root = certificate.prev_local_exit_tree.get_root();
 
-        if computed_root != batch.prev_local_exit_root {
+        if computed_root != certificate.prev_local_exit_root {
             return Err(ProofError::InvalidLocalExitRoot {
                 got: computed_root,
-                expected: batch.prev_local_exit_root,
+                expected: certificate.prev_local_exit_root,
             });
         }
     }
 
     // Compute the new exit root
-    let exit_roots: HashMap<NetworkId, ExitRoot> = batches
+    let exit_roots: HashMap<NetworkId, ExitRoot> = certificates
         .iter()
-        .map(|batch| (batch.origin_network, batch.compute_new_exit_root()))
+        .map(|certificate| (certificate.origin_network, certificate.compute_new_exit_root()))
         .collect();
 
     // Compute the new balance tree by network
-    let balance_trees: HashMap<NetworkId, BalanceTreeByNetwork> = batches
+    let balance_trees: HashMap<NetworkId, BalanceTreeByNetwork> = certificates
         .iter()
-        .map(|batch| (batch.origin_network, batch.compute_new_balance_tree()))
+        .map(|certificate| (certificate.origin_network, certificate.compute_new_balance_tree()))
         .collect();
 
     // Merge the balance tree by network

--- a/pessimistic_proof/tests/full_proof.rs
+++ b/pessimistic_proof/tests/full_proof.rs
@@ -1,23 +1,25 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use lazy_static::lazy_static;
 use poly_pessimistic_proof::{
     certificate::Certificate,
-    generate_full_proof,
-    local_balance_tree::{Balance, BalanceTree, Deposit},
+    generate_full_proof_with_state,
+    local_balance_tree::{Balance, BalanceTree, BalanceTreeByNetwork, Deposit},
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
-    FullProofOutput, NetworkId, ProofError, TokenInfo, Withdrawal,
+    NetworkId, ProofError, State, TokenInfo, Withdrawal,
 };
 use reth_primitives::{address, U256};
 use rstest::{fixture, rstest};
 
 lazy_static! {
+    pub static ref NETWORK_A: NetworkId = 0.into();
+    pub static ref NETWORK_B: NetworkId = 1.into();
     pub static ref USDC: TokenInfo = TokenInfo {
-        origin_network: 0.into(),
+        origin_network: *NETWORK_A,
         origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
     };
     pub static ref ETH: TokenInfo = TokenInfo {
-        origin_network: 0.into(),
+        origin_network: *NETWORK_A,
         origin_token_address: address!("0000000000000000000000000000000000000000"),
     };
 }
@@ -34,55 +36,6 @@ fn make_tx(_from: u32, to: u32, token: &TokenInfo, amount: u32) -> Withdrawal {
     )
 }
 
-pub struct State {
-    pub global_exit_tree: HashMap<NetworkId, LocalExitTree<Keccak256Hasher>>,
-    pub global_balance_tree: HashMap<NetworkId, BalanceTree>,
-}
-
-pub fn generate_full_proof_with_state(
-    initial_state: State,
-    certificates: &mut [Certificate],
-) -> Result<FullProofOutput, ProofError> {
-    // TODO: do not embed the full state in the certificates
-    for c in certificates.iter_mut() {
-        c.prev_local_balance_tree = initial_state
-            .global_balance_tree
-            .get(&c.origin_network)
-            .expect("non-existent network")
-            .clone();
-
-        let exit_tree = initial_state
-            .global_exit_tree
-            .get(&c.origin_network)
-            .expect("non-existent network")
-            .clone();
-
-        c.prev_local_exit_root = exit_tree.get_root();
-        c.prev_local_exit_tree = exit_tree;
-    }
-
-    generate_full_proof(certificates)
-}
-
-#[fixture]
-fn initial_state() -> State {
-    let deposit_eth =
-        |v: u32| -> (TokenInfo, Balance) { (ETH.clone(), Deposit(U256::from(v)).into()) };
-    let deposit_usdc =
-        |v: u32| -> (TokenInfo, Balance) { (USDC.clone(), Deposit(U256::from(v)).into()) };
-
-    let dummy_let = LocalExitTree::from_leaves([[0_u8; 32], [1_u8; 32], [2_u8; 32]].into_iter());
-    //let dummy_ler = dummy_let.get_root();
-
-    let initial_0 = BalanceTree::from(vec![deposit_eth(10), deposit_usdc(10)]);
-    let initial_1 = BalanceTree::from(vec![deposit_eth(1), deposit_usdc(200)]);
-
-    State {
-        global_exit_tree: [(0.into(), dummy_let.clone()), (1.into(), dummy_let.clone())].into(),
-        global_balance_tree: [(0.into(), initial_0), (1.into(), initial_1)].into(),
-    }
-}
-
 #[fixture]
 fn state_transition() -> Vec<Certificate> {
     let eth = ETH.clone();
@@ -93,52 +46,87 @@ fn state_transition() -> Vec<Certificate> {
     let withdraw_0_to_1 = vec![make_tx(0, 1, &eth, 10), make_tx(0, 1, &usdc, 100)];
     let withdraw_1_to_0 = vec![make_tx(1, 0, &eth, 20), make_tx(1, 0, &usdc, 200)];
 
+    let dummy_let: LocalExitTree<Keccak256Hasher> =
+        LocalExitTree::from_leaves([[0_u8; 32], [1_u8; 32], [2_u8; 32]].into_iter());
+
     vec![
-        Certificate::new(
-            0.into(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            withdraw_0_to_1.clone(),
-        ),
-        Certificate::new(
-            1.into(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            withdraw_1_to_0.clone(),
-        ),
+        Certificate::new(*NETWORK_A, dummy_let.get_root(), withdraw_0_to_1.clone()),
+        Certificate::new(*NETWORK_B, dummy_let.get_root(), withdraw_1_to_0.clone()),
     ]
 }
 
-#[rstest]
-fn should_detect_debtor(initial_state: State, mut state_transition: Vec<Certificate>) {
-    // Compute the full proof
-    assert!(matches!(
-        generate_full_proof_with_state(initial_state, &mut state_transition),
-        Err(ProofError::NotEnoughBalance { .. })
-    ));
+mod should_detect_debtor {
+    use super::*;
+
+    #[fixture]
+    fn initial_state() -> State {
+        let deposit_eth =
+            |v: u32| -> (TokenInfo, Balance) { (ETH.clone(), Deposit(U256::from(v)).into()) };
+        let deposit_usdc =
+            |v: u32| -> (TokenInfo, Balance) { (USDC.clone(), Deposit(U256::from(v)).into()) };
+
+        let dummy_let =
+            LocalExitTree::from_leaves([[0_u8; 32], [1_u8; 32], [2_u8; 32]].into_iter());
+
+        let initial_0 = BalanceTree::from(vec![deposit_eth(10), deposit_usdc(10)]);
+        let initial_1 = BalanceTree::from(vec![deposit_eth(1), deposit_usdc(200)]);
+
+        let global_balance_tree: BalanceTreeByNetwork = {
+            let base: BTreeMap<NetworkId, BalanceTree> =
+                [(*NETWORK_A, initial_0), (*NETWORK_B, initial_1)].into();
+            base.into()
+        };
+
+        State {
+            global_exit_tree: [(*NETWORK_A, dummy_let.clone()), (*NETWORK_B, dummy_let.clone())]
+                .into(),
+            global_balance_tree,
+        }
+    }
+
+    #[rstest]
+    fn prove(initial_state: State, state_transition: Vec<Certificate>) {
+        assert!(matches!(
+            generate_full_proof_with_state(initial_state, state_transition),
+            Err(ProofError::NotEnoughBalance { .. })
+        ));
+    }
 }
-// Success case
-// {
-//     // Initial balances for the CDKs
-//     let initial_0 = BalanceTree::from(vec![deposit_eth(12), deposit_usdc(102)]);
-//     let initial_1 = BalanceTree::from(vec![deposit_eth(20), deposit_usdc(201)]);
 
-//     let certificates = vec![
-//         Certificate::new(
-//             0.into(),
-//             dummy.clone(),
-//             dummy_root.clone(),
-//             initial_0,
-//             withdraw_0_to_1.clone(),
-//         ),
-//         Certificate::new(1.into(), dummy, dummy_root, initial_1, withdraw_1_to_0.clone()),
-//     ];
+mod should_succeed {
+    use super::*;
 
-//     // Compute the full proof
-//     assert!(generate_full_proof(&certificates).is_ok());
-// }
+    #[fixture]
+    fn initial_state() -> State {
+        let deposit_eth =
+            |v: u32| -> (TokenInfo, Balance) { (ETH.clone(), Deposit(U256::from(v)).into()) };
+        let deposit_usdc =
+            |v: u32| -> (TokenInfo, Balance) { (USDC.clone(), Deposit(U256::from(v)).into()) };
+
+        let dummy_let =
+            LocalExitTree::from_leaves([[0_u8; 32], [1_u8; 32], [2_u8; 32]].into_iter());
+
+        let initial_0 = BalanceTree::from(vec![deposit_eth(12), deposit_usdc(102)]);
+        let initial_1 = BalanceTree::from(vec![deposit_eth(20), deposit_usdc(201)]);
+
+        let global_balance_tree: BalanceTreeByNetwork = {
+            let base: BTreeMap<NetworkId, BalanceTree> =
+                [(*NETWORK_A, initial_0), (*NETWORK_B, initial_1)].into();
+            base.into()
+        };
+
+        State {
+            global_exit_tree: [(*NETWORK_A, dummy_let.clone()), (*NETWORK_B, dummy_let.clone())]
+                .into(),
+            global_balance_tree,
+        }
+    }
+
+    #[rstest]
+    fn prove(initial_state: State, state_transition: Vec<Certificate>) {
+        assert!(generate_full_proof_with_state(initial_state, state_transition).is_ok())
+    }
+}
 
 #[test]
 #[ignore = "not implemented yet"]

--- a/pessimistic_proof/tests/full_proof.rs
+++ b/pessimistic_proof/tests/full_proof.rs
@@ -1,11 +1,26 @@
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
 use poly_pessimistic_proof::{
     certificate::Certificate,
     generate_full_proof,
     local_balance_tree::{Balance, BalanceTree, Deposit},
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
-    ProofError, TokenInfo, Withdrawal,
+    FullProofOutput, NetworkId, ProofError, TokenInfo, Withdrawal,
 };
 use reth_primitives::{address, U256};
+use rstest::{fixture, rstest};
+
+lazy_static! {
+    pub static ref USDC: TokenInfo = TokenInfo {
+        origin_network: 0.into(),
+        origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+    };
+    pub static ref ETH: TokenInfo = TokenInfo {
+        origin_network: 0.into(),
+        origin_token_address: address!("0000000000000000000000000000000000000000"),
+    };
+}
 
 fn make_tx(_from: u32, to: u32, token: &TokenInfo, amount: u32) -> Withdrawal {
     Withdrawal::new(
@@ -19,84 +34,111 @@ fn make_tx(_from: u32, to: u32, token: &TokenInfo, amount: u32) -> Withdrawal {
     )
 }
 
-#[test]
-fn test_full_proof() {
-    let eth = TokenInfo {
-        origin_network: 0.into(),
-        origin_token_address: address!("0000000000000000000000000000000000000000"),
-    };
+pub struct State {
+    pub global_exit_tree: HashMap<NetworkId, LocalExitTree<Keccak256Hasher>>,
+    pub global_balance_tree: HashMap<NetworkId, BalanceTree>,
+}
 
-    let usdc = TokenInfo {
-        origin_network: 0.into(),
-        origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
-    };
+pub fn generate_full_proof_with_state(
+    initial_state: State,
+    certificates: &mut [Certificate],
+) -> Result<FullProofOutput, ProofError> {
+    // TODO: do not embed the full state in the certificates
+    for c in certificates.iter_mut() {
+        c.prev_local_balance_tree = initial_state
+            .global_balance_tree
+            .get(&c.origin_network)
+            .expect("non-existent network")
+            .clone();
 
-    let dummy: LocalExitTree<Keccak256Hasher> =
-        LocalExitTree::from_leaves([[0_u8; 32], [1_u8; 32], [2_u8; 32]].into_iter());
-    let dummy_root = dummy.get_root();
+        let exit_tree = initial_state
+            .global_exit_tree
+            .get(&c.origin_network)
+            .expect("non-existent network")
+            .clone();
+
+        c.prev_local_exit_root = exit_tree.get_root();
+        c.prev_local_exit_tree = exit_tree;
+    }
+
+    generate_full_proof(certificates)
+}
+
+#[fixture]
+fn initial_state() -> State {
+    let deposit_eth =
+        |v: u32| -> (TokenInfo, Balance) { (ETH.clone(), Deposit(U256::from(v)).into()) };
+    let deposit_usdc =
+        |v: u32| -> (TokenInfo, Balance) { (USDC.clone(), Deposit(U256::from(v)).into()) };
+
+    let dummy_let = LocalExitTree::from_leaves([[0_u8; 32], [1_u8; 32], [2_u8; 32]].into_iter());
+    //let dummy_ler = dummy_let.get_root();
+
+    let initial_0 = BalanceTree::from(vec![deposit_eth(10), deposit_usdc(10)]);
+    let initial_1 = BalanceTree::from(vec![deposit_eth(1), deposit_usdc(200)]);
+
+    State {
+        global_exit_tree: [(0.into(), dummy_let.clone()), (1.into(), dummy_let.clone())].into(),
+        global_balance_tree: [(0.into(), initial_0), (1.into(), initial_1)].into(),
+    }
+}
+
+#[fixture]
+fn state_transition() -> Vec<Certificate> {
+    let eth = ETH.clone();
+    let usdc = USDC.clone();
 
     // Prepare the data fetched from the CDK: Withdrawals + LBT
-
     // Withdrawals
     let withdraw_0_to_1 = vec![make_tx(0, 1, &eth, 10), make_tx(0, 1, &usdc, 100)];
     let withdraw_1_to_0 = vec![make_tx(1, 0, &eth, 20), make_tx(1, 0, &usdc, 200)];
 
-    let deposit_eth =
-        |v: u32| -> (TokenInfo, Balance) { (eth.clone(), Deposit(U256::from(v)).into()) };
-    let deposit_usdc =
-        |v: u32| -> (TokenInfo, Balance) { (usdc.clone(), Deposit(U256::from(v)).into()) };
-
-    // Failing case
-    {
-        // Initial balances for the CDKs
-        let initial_0 = BalanceTree::from(vec![deposit_eth(10), deposit_usdc(10)]);
-        let initial_1 = BalanceTree::from(vec![deposit_eth(1), deposit_usdc(200)]);
-
-        let certificates = vec![
-            Certificate::new(
-                0.into(),
-                dummy.clone(),
-                dummy_root.clone(),
-                initial_0,
-                withdraw_0_to_1.clone(),
-            ),
-            Certificate::new(
-                1.into(),
-                dummy.clone(),
-                dummy_root.clone(),
-                initial_1,
-                withdraw_1_to_0.clone(),
-            ),
-        ];
-
-        // Compute the full proof
-        assert!(matches!(
-            generate_full_proof(&certificates),
-            Err(ProofError::NotEnoughBalance { .. })
-        ));
-    }
-
-    // Success case
-    {
-        // Initial balances for the CDKs
-        let initial_0 = BalanceTree::from(vec![deposit_eth(12), deposit_usdc(102)]);
-        let initial_1 = BalanceTree::from(vec![deposit_eth(20), deposit_usdc(201)]);
-
-        let certificates = vec![
-            Certificate::new(
-                0.into(),
-                dummy.clone(),
-                dummy_root.clone(),
-                initial_0,
-                withdraw_0_to_1.clone(),
-            ),
-            Certificate::new(1.into(), dummy, dummy_root, initial_1, withdraw_1_to_0.clone()),
-        ];
-
-        // Compute the full proof
-        assert!(generate_full_proof(&certificates).is_ok());
-    }
+    vec![
+        Certificate::new(
+            0.into(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            withdraw_0_to_1.clone(),
+        ),
+        Certificate::new(
+            1.into(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            withdraw_1_to_0.clone(),
+        ),
+    ]
 }
+
+#[rstest]
+fn should_detect_debtor(initial_state: State, mut state_transition: Vec<Certificate>) {
+    // Compute the full proof
+    assert!(matches!(
+        generate_full_proof_with_state(initial_state, &mut state_transition),
+        Err(ProofError::NotEnoughBalance { .. })
+    ));
+}
+// Success case
+// {
+//     // Initial balances for the CDKs
+//     let initial_0 = BalanceTree::from(vec![deposit_eth(12), deposit_usdc(102)]);
+//     let initial_1 = BalanceTree::from(vec![deposit_eth(20), deposit_usdc(201)]);
+
+//     let certificates = vec![
+//         Certificate::new(
+//             0.into(),
+//             dummy.clone(),
+//             dummy_root.clone(),
+//             initial_0,
+//             withdraw_0_to_1.clone(),
+//         ),
+//         Certificate::new(1.into(), dummy, dummy_root, initial_1, withdraw_1_to_0.clone()),
+//     ];
+
+//     // Compute the full proof
+//     assert!(generate_full_proof(&certificates).is_ok());
+// }
 
 #[test]
 #[ignore = "not implemented yet"]

--- a/pessimistic_proof/tests/full_proof.rs
+++ b/pessimistic_proof/tests/full_proof.rs
@@ -1,5 +1,5 @@
 use poly_pessimistic_proof::{
-    batch::Batch,
+    certificate::Certificate,
     generate_full_proof,
     local_balance_tree::{Balance, BalanceTree, Deposit},
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
@@ -52,15 +52,15 @@ fn test_full_proof() {
         let initial_0 = BalanceTree::from(vec![deposit_eth(10), deposit_usdc(10)]);
         let initial_1 = BalanceTree::from(vec![deposit_eth(1), deposit_usdc(200)]);
 
-        let batches = vec![
-            Batch::new(
+        let certificates = vec![
+            Certificate::new(
                 0.into(),
                 dummy.clone(),
                 dummy_root.clone(),
                 initial_0,
                 withdraw_0_to_1.clone(),
             ),
-            Batch::new(
+            Certificate::new(
                 1.into(),
                 dummy.clone(),
                 dummy_root.clone(),
@@ -71,7 +71,7 @@ fn test_full_proof() {
 
         // Compute the full proof
         assert!(matches!(
-            generate_full_proof(&batches),
+            generate_full_proof(&certificates),
             Err(ProofError::NotEnoughBalance { .. })
         ));
     }
@@ -82,19 +82,19 @@ fn test_full_proof() {
         let initial_0 = BalanceTree::from(vec![deposit_eth(12), deposit_usdc(102)]);
         let initial_1 = BalanceTree::from(vec![deposit_eth(20), deposit_usdc(201)]);
 
-        let batches = vec![
-            Batch::new(
+        let certificates = vec![
+            Certificate::new(
                 0.into(),
                 dummy.clone(),
                 dummy_root.clone(),
                 initial_0,
                 withdraw_0_to_1.clone(),
             ),
-            Batch::new(1.into(), dummy, dummy_root, initial_1, withdraw_1_to_0.clone()),
+            Certificate::new(1.into(), dummy, dummy_root, initial_1, withdraw_1_to_0.clone()),
         ];
 
         // Compute the full proof
-        assert!(generate_full_proof(&batches).is_ok());
+        assert!(generate_full_proof(&certificates).is_ok());
     }
 }
 

--- a/program/src/main.rs
+++ b/program/src/main.rs
@@ -1,13 +1,14 @@
 #![no_main]
 
-use poly_pessimistic_proof::{certificate::Certificate, generate_full_proof};
+use poly_pessimistic_proof::{certificate::Certificate, generate_full_proof_with_state, State};
 
 sp1_zkvm::entrypoint!(main);
 
 pub fn main() {
+    let initial_state = sp1_zkvm::io::read::<State>();
     let certificates = sp1_zkvm::io::read::<Vec<Certificate>>();
 
-    let new_roots = generate_full_proof(&certificates).unwrap();
+    let new_roots = generate_full_proof_with_state(initial_state, certificates).unwrap();
 
     sp1_zkvm::io::commit(&new_roots);
 }

--- a/program/src/main.rs
+++ b/program/src/main.rs
@@ -1,13 +1,13 @@
 #![no_main]
 
-use poly_pessimistic_proof::{batch::Batch, generate_full_proof};
+use poly_pessimistic_proof::{certificate::Certificate, generate_full_proof};
 
 sp1_zkvm::entrypoint!(main);
 
 pub fn main() {
-    let batches = sp1_zkvm::io::read::<Vec<Batch>>();
+    let certificates = sp1_zkvm::io::read::<Vec<Certificate>>();
 
-    let new_roots = generate_full_proof(&batches).unwrap();
+    let new_roots = generate_full_proof(&certificates).unwrap();
 
     sp1_zkvm::io::commit(&new_roots);
 }

--- a/script/src/main.rs
+++ b/script/src/main.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::Instant};
 
 use poly_pessimistic_proof::{
-    batch::Batch,
+    certificate::Certificate,
     keccak::Digest as KeccakDigest,
     local_balance_tree::{Balance, BalanceTree, Deposit},
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
@@ -16,7 +16,7 @@ const WITHDRAWALS_JSON_FILE_PATH: &str = "src/data/withdrawals.json";
 
 const INITIAL_LEAF_COUNT: u32 = 1853;
 
-fn make_batch(origin_network: NetworkId) -> Batch {
+fn make_certificate(origin_network: NetworkId) -> Certificate {
     let withdrawals: Vec<Withdrawal> = {
         let deposit_event_data: Vec<DepositEventData> = parse_json_file(WITHDRAWALS_JSON_FILE_PATH);
 
@@ -81,7 +81,7 @@ fn make_batch(origin_network: NetworkId) -> Batch {
 
     let prev_local_exit_root = prev_local_exit_tree.get_root();
 
-    Batch {
+    Certificate {
         origin_network,
         prev_local_exit_tree,
         prev_local_exit_root,
@@ -98,10 +98,10 @@ fn main() {
     let client = ProverClient::new();
     let (proving_key, verifying_key) = client.setup(ELF);
 
-    // Make a single batch from network 0.
+    // Make a single certificate from network 0.
     let origin_network: NetworkId = 0.into();
-    let batches = vec![make_batch(origin_network)];
-    stdin.write(&batches);
+    let certificates = vec![make_certificate(origin_network)];
+    stdin.write(&certificates);
 
     let now = Instant::now();
     let mut proof = client.prove(&proving_key, stdin).expect("proving failed");

--- a/script/src/main.rs
+++ b/script/src/main.rs
@@ -1,28 +1,26 @@
-use std::{collections::HashMap, time::Instant};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Instant,
+};
 
 use poly_pessimistic_proof::{
     certificate::Certificate,
     keccak::Digest as KeccakDigest,
-    local_balance_tree::{Balance, BalanceTree, Deposit},
+    local_balance_tree::{Balance, BalanceTree, BalanceTreeByNetwork, Deposit},
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
     test_utils::{parse_json_file, DepositEventData},
-    NetworkId, TokenInfo, Withdrawal,
+    NetworkId, State, TokenInfo, Withdrawal,
 };
 use reth_primitives::{address, U256};
 use sp1_sdk::{ProverClient, SP1Stdin};
 
 const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
 const WITHDRAWALS_JSON_FILE_PATH: &str = "src/data/withdrawals.json";
-
 const INITIAL_LEAF_COUNT: u32 = 1853;
+const ORIGIN_NETWORK: u32 = 0;
 
-fn make_certificate(origin_network: NetworkId) -> Certificate {
-    let withdrawals: Vec<Withdrawal> = {
-        let deposit_event_data: Vec<DepositEventData> = parse_json_file(WITHDRAWALS_JSON_FILE_PATH);
-
-        deposit_event_data.into_iter().map(Into::into).collect()
-    };
-
+fn make_proof_inputs() -> (State, Vec<Certificate>) {
+    let origin_network = ORIGIN_NETWORK.into();
     let prev_local_exit_tree: LocalExitTree<Keccak256Hasher> = LocalExitTree::from_parts(
         INITIAL_LEAF_COUNT,
         [
@@ -61,33 +59,54 @@ fn make_certificate(origin_network: NetworkId) -> Certificate {
         ],
     );
 
-    let prev_local_balance_tree: BalanceTree = {
-        let eth = TokenInfo {
-            origin_network: origin_network.clone(),
-            origin_token_address: address!("0000000000000000000000000000000000000000"),
+    let certificate = {
+        let withdrawals: Vec<Withdrawal> = {
+            let deposit_event_data: Vec<DepositEventData> =
+                parse_json_file(WITHDRAWALS_JSON_FILE_PATH);
+
+            deposit_event_data.into_iter().map(Into::into).collect()
         };
 
-        let token = TokenInfo {
-            origin_network: origin_network.clone(),
-            origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
-        };
-
-        let infinite_eth = || -> (TokenInfo, Balance) { (eth.clone(), Deposit(U256::MAX).into()) };
-        let infinite_token =
-            || -> (TokenInfo, Balance) { (token.clone(), Deposit(U256::MAX).into()) };
-
-        BalanceTree::from(vec![infinite_eth(), infinite_token()])
+        Certificate {
+            origin_network,
+            prev_local_exit_root: prev_local_exit_tree.get_root(),
+            withdrawals,
+        }
     };
 
-    let prev_local_exit_root = prev_local_exit_tree.get_root();
+    let initial_state = {
+        let prev_local_balance_tree: BalanceTree = {
+            let eth = TokenInfo {
+                origin_network: origin_network.clone(),
+                origin_token_address: address!("0000000000000000000000000000000000000000"),
+            };
 
-    Certificate {
-        origin_network,
-        prev_local_exit_tree,
-        prev_local_exit_root,
-        prev_local_balance_tree,
-        withdrawals,
-    }
+            let token = TokenInfo {
+                origin_network: origin_network.clone(),
+                origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+            };
+
+            let infinite_eth =
+                || -> (TokenInfo, Balance) { (eth.clone(), Deposit(U256::MAX).into()) };
+            let infinite_token =
+                || -> (TokenInfo, Balance) { (token.clone(), Deposit(U256::MAX).into()) };
+
+            BalanceTree::from(vec![infinite_eth(), infinite_token()])
+        };
+
+        let global_balance_tree: BalanceTreeByNetwork = {
+            let base: BTreeMap<NetworkId, BalanceTree> =
+                [(origin_network, prev_local_balance_tree)].into();
+            base.into()
+        };
+
+        State {
+            global_exit_tree: [(origin_network, prev_local_exit_tree)].into(),
+            global_balance_tree,
+        }
+    };
+
+    (initial_state, vec![certificate])
 }
 
 fn main() {
@@ -98,9 +117,8 @@ fn main() {
     let client = ProverClient::new();
     let (proving_key, verifying_key) = client.setup(ELF);
 
-    // Make a single certificate from network 0.
-    let origin_network: NetworkId = 0.into();
-    let certificates = vec![make_certificate(origin_network)];
+    let (initial_state, certificates) = make_proof_inputs();
+    stdin.write(&initial_state);
     stdin.write(&certificates);
 
     let now = Instant::now();
@@ -108,6 +126,7 @@ fn main() {
     let prover_time = now.elapsed();
 
     // Read output.
+    let origin_network = ORIGIN_NETWORK.into();
     let new_roots: HashMap<NetworkId, (KeccakDigest, KeccakDigest)> = proof.public_values.read();
     let (exit_root, _balance_root) = new_roots.get(&origin_network).expect("nonexistent network");
 


### PR DESCRIPTION
Adapt the pessimistic proof inputs as per the specs:

**Inputs**
- Current `GlobalExitTree` and `GlobalBalanceTree`
- Set of `Certificate`

Closes #15 